### PR TITLE
updated QT .pro file to allow the serialport lib to be included when …

### DIFF
--- a/DroidStar.pro
+++ b/DroidStar.pro
@@ -1,6 +1,7 @@
 QT += quick quickcontrols2 network multimedia
 android:QT += androidextras
 linux:QT += serialport
+unix:QT += serialport
 CONFIG += c++11
 LFLAGS +=
 android:INCLUDEPATH += $$(HOME)/Android/android-build/include


### PR DESCRIPTION
I updated QT .pro file to allow the serialport lib to be included when building on FreeBSD.