### PR TITLE
HTTP -> HTTPS redirection problem fix.

### DIFF
--- a/httpmanager.cpp
+++ b/httpmanager.cpp
@@ -40,7 +40,7 @@ void HttpManager::doRequest()
 		m_qnam->get(QNetworkRequest(QUrl(m_filename)));
 	}
 	else{
-		m_qnam->get(QNetworkRequest(QUrl("http://www.dudetronics.com/ar-dns" + m_filename)));
+		m_qnam->get(QNetworkRequest(QUrl("https://www.dudetronics.com/ar-dns" + m_filename)));
 	}
 	//qDebug() << "doRequest() called m_filename == " << m_filename;
 }


### PR DESCRIPTION
From today server redirects HTTP->HTTPS, that causes impossibility to download DMRHosts.txt and other files:
`cat ~/.config/dudetronics/DMRHosts.txt
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://www.dudetronics.com/ar-dns/DMRHosts.txt">here</a>.</p>
</body></html>
`
This PR changes the downloading url to use https.