### PR TITLE
fix(dmr): MSTCL/MSTNAK reconnect never fires

### DIFF
--- a/dmr.cpp
+++ b/dmr.cpp
@@ -115,8 +115,9 @@ void DMR::process_udp()
 		emit update(m_modeinfo);
 	// Simulate pressing the main connect button so the UI shows disconnected,
 	// then request a reconnect after a 10s timeout using the same hook.
-	emit request_connect_toggle();
+	// Reconnect must be queued before disconnect destroys this object
 	emit request_reconnect(10000);
+	emit request_connect_toggle();
 		return;
 	}
 	// Handle MSTCL - Master close (server shutting down)
@@ -134,8 +135,9 @@ void DMR::process_udp()
 		emit update(m_modeinfo);
 	// Simulate pressing the main connect button to show disconnected state,
 	// then request a reconnect after 10 seconds via the main app hook.
-	emit request_connect_toggle();
+	// Reconnect must be queued before disconnect destroys this object
 	emit request_reconnect(10000);
+	emit request_connect_toggle();
 		return;
 	}
 	if((m_modeinfo.status != CONNECTED_RW) && (::memcmp(buf.data(), "RPTACK", 6U) == 0)){


### PR DESCRIPTION
When receiving MSTCL or MSTNAK, the DMR mode object emits two cross-thread signals: `request_connect_toggle()` to disconnect, and `request_reconnect()` to schedule a 10-second reconnect timer.

Because the mode object lives on `m_modethread` while DroidStar lives on the main thread, both signals use `Qt::QueuedConnection`. They are delivered in the order they were emitted. The original code emitted `request_connect_toggle()` first, which queued `process_connect()` on the main thread. When that slot ran, it called `m_modethread->quit()`, which triggered the thread's `finished()` signal, which invoked `m_mode->deleteLater()`. By the time the event loop got to the second queued signal (`request_reconnect`), the sender object was already destroyed and Qt had silently disconnected it, so `schedule_reconnect()` was never called.

This fix swaps the emit order so `request_reconnect()` is queued first. The main thread event loop then processes `schedule_reconnect()` (which just starts a `QTimer::singleShot`) before `process_connect()` tears down the mode object.