### PR TITLE
Android: wrap UI content in safe area Item to avoid system bar overlap

### DIFF
--- a/Main.qml
+++ b/Main.qml
@@ -51,77 +51,90 @@ ApplicationWindow {
 		text: "No hardware or software vocoder found for this mode. You can still connect, but you will not RX or TX any audio. See the project website (url on the About tab) for info on loading a sw vocoder, or use a USB AMBE dongle (and an OTG adapter on Android devices)"
 	}
 
-	TabBar {
-		id: bar
-		width: parent.width
-		currentIndex: swiper.currentIndex
-		background: Rectangle {
-			color: "steelblue"
-		}
-		TabButton {
-			id: mainButton
-			padding: 10
-			background: Rectangle {
-				color: bar.currentIndex === 0 ? "steelblue" : "#353535"
-			}
-			text: qsTr("Main")
-		}
-		TabButton {
-			id: settingsButton
-			padding: 10
-			background: Rectangle {
-				color: bar.currentIndex === 1 ? "steelblue" : "#353535"
-			}
-			text: qsTr("Settings")
-		}
-		TabButton {
-			id: logButton
-			padding: 10
-			background: Rectangle {
-				color: bar.currentIndex === 2 ? "steelblue" : "#353535"
-			}
-			text: qsTr("Log")
-		}
-		TabButton {
-			id: hostsButton
-			padding: 10
-			background: Rectangle {
-				color: bar.currentIndex === 3 ? "steelblue" : "#353535"
-			}
-			text: qsTr("Hosts")
-		}
-		TabButton {
-			id: aboutButton
-			padding: 10
-			background: Rectangle {
-				color: bar.currentIndex === 4 ? "steelblue" : "#353535"
-			}
-			text: qsTr("About")
-		}
-	}
-	SwipeView {
-		id: swiper
-		width: parent.width
-		height: parent.height - 50
-		x: 0
-		y: 50
-		currentIndex: bar.currentIndex
-		interactive: false
+	// Inset all visible content by the device safe area so the TabBar and
+	// content don't draw under the status bar / camera cutout / nav bar.
+	// Margins are read from contentItem (which spans the full window) and
+	// applied to this child to avoid a safe-area feedback loop.
+	Item {
+		id: safeArea
+		anchors.fill: parent
+		anchors.topMargin: main.contentItem.SafeArea.margins.top
+		anchors.bottomMargin: main.contentItem.SafeArea.margins.bottom
+		anchors.leftMargin: main.contentItem.SafeArea.margins.left
+		anchors.rightMargin: main.contentItem.SafeArea.margins.right
 
-		MainTab{
-			id: mainTab
+		TabBar {
+			id: bar
+			width: parent.width
+			currentIndex: swiper.currentIndex
+			background: Rectangle {
+				color: "steelblue"
+			}
+			TabButton {
+				id: mainButton
+				padding: 10
+				background: Rectangle {
+					color: bar.currentIndex === 0 ? "steelblue" : "#353535"
+				}
+				text: qsTr("Main")
+			}
+			TabButton {
+				id: settingsButton
+				padding: 10
+				background: Rectangle {
+					color: bar.currentIndex === 1 ? "steelblue" : "#353535"
+				}
+				text: qsTr("Settings")
+			}
+			TabButton {
+				id: logButton
+				padding: 10
+				background: Rectangle {
+					color: bar.currentIndex === 2 ? "steelblue" : "#353535"
+				}
+				text: qsTr("Log")
+			}
+			TabButton {
+				id: hostsButton
+				padding: 10
+				background: Rectangle {
+					color: bar.currentIndex === 3 ? "steelblue" : "#353535"
+				}
+				text: qsTr("Hosts")
+			}
+			TabButton {
+				id: aboutButton
+				padding: 10
+				background: Rectangle {
+					color: bar.currentIndex === 4 ? "steelblue" : "#353535"
+				}
+				text: qsTr("About")
+			}
 		}
-		SettingsTab{
-			id: settingsTab
+		SwipeView {
+			id: swiper
+			width: parent.width
+			height: parent.height - 50
+			x: 0
+			y: 50
+			currentIndex: bar.currentIndex
+			interactive: false
+
+			MainTab{
+				id: mainTab
+			}
+			SettingsTab{
+				id: settingsTab
+			}
+			LogTab{
+				id: logTab
+			}
+			HostsTab{
+				id: hostsTab
+			}
+			AboutTab{}
 		}
-		LogTab{
-			id: logTab
-		}
-		HostsTab{
-			id: hostsTab
-		}
-		AboutTab{}
-	}
+	} // safeArea
     DroidStar {
         id: droidstar
     }


### PR DESCRIPTION
Insets the TabBar and SwipeView inside a SafeArea-aware Item so content does not render under the Android status bar, camera cutout, or nav bar.

Effective changes are from line 54 to 65. Lines below are just indentations.

Before
<img width="540" height="1200" alt="before" src="https://github.com/user-attachments/assets/3507946b-6e0e-4f78-bc3e-9b0d7a0c2393" />

After
<img width="540" height="1200" alt="after" src="https://github.com/user-attachments/assets/a24bfb47-8320-44c6-b3d1-f9e3f8582a05" />


