### PR TITLE
Add CMake build option for MD380 vocoder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,8 @@ if(FALSE) # set TRUE for flite
     )
 endif()
 
-if(TRUE) # set TRUE for md380_vocoder
+option(USE_MD380_VOCODER "Build with MD380 vocoder (ARM only)" OFF)
+if(USE_MD380_VOCODER)
     target_compile_definitions(DroidStar PRIVATE
         USE_MD380_VOCODER
     )

--- a/droidstar.cpp
+++ b/droidstar.cpp
@@ -246,12 +246,12 @@ void DroidStar::obtain_asl_wt_creds()
 	postData.append("user=" + QUrl::toPercentEncoding(m_callsign.toUtf8()));
 	postData.append("&pass=" + QUrl::toPercentEncoding(m_asl_password.toUtf8()));
 
-	connect(manager, &QNetworkAccessManager::finished, this, [=](QNetworkReply *reply) {
+	connect(manager, &QNetworkAccessManager::finished, this, [=, this](QNetworkReply *reply) {
 		if (reply->error() == QNetworkReply::NoError) {
 			QUrl url("https://www.allstarlink.org/portal/webtransceiver.php?node=12345");
 			QNetworkRequest request(url);
-			
-			connect(manager, &QNetworkAccessManager::finished, this, [=](QNetworkReply *reply) {
+
+			connect(manager, &QNetworkAccessManager::finished, this, [=, this](QNetworkReply *reply) {
 				if (reply->error() == QNetworkReply::NoError) {
 					QString html = reply->readAll();
 					QStringList l = html.split('\n');


### PR DESCRIPTION
Replaces hardcoded `if(TRUE)` with `USE_MD380_VOCODER` option (default OFF), allowing the vocoder to be enabled at configure time with `-DUSE_MD380_VOCODER=ON`.

Also fixes deprecated implicit this capture in C++20 lambdas.